### PR TITLE
Search for all keywords and documents if fuzziness is enabled

### DIFF
--- a/src/TNTSearch.php
+++ b/src/TNTSearch.php
@@ -226,7 +226,7 @@ class TNTSearch
             return $this->getAllDocumentsForFuzzyKeyword($word, $noLimit);
         }
 
-        return $this->getAllDocumentsForStrictKeyword($noLimit, $word);
+        return $this->getAllDocumentsForStrictKeyword($word, $noLimit);
     }
 
     public function getAllDocumentsForWhereKeywordNot($keyword, $noLimit = false)

--- a/src/TNTSearch.php
+++ b/src/TNTSearch.php
@@ -222,15 +222,11 @@ class TNTSearch
         if (!isset($word[0])) {
             return new Collection([]);
         }
-        $query = "SELECT * FROM doclist WHERE term_id = :id ORDER BY hit_count DESC LIMIT {$this->maxDocs}";
-        if ($noLimit) {
-            $query = "SELECT * FROM doclist WHERE term_id = :id ORDER BY hit_count DESC";
+        if ($this->fuzziness) {
+            return $this->getAllDocumentsForFuzzyKeyword($word, $noLimit);
         }
-        $stmtDoc = $this->index->prepare($query);
 
-        $stmtDoc->bindValue(':id', $word[0]['id']);
-        $stmtDoc->execute();
-        return new Collection($stmtDoc->fetchAll(PDO::FETCH_ASSOC));
+        return $this->getAllDocumentsForStrictKeyword($noLimit, $word);
     }
 
     public function getAllDocumentsForWhereKeywordNot($keyword, $noLimit = false)
@@ -367,5 +363,35 @@ class TNTSearch
         $indexer->setIndex($this->index);
         $indexer->setStemmer($this->stemmer);
         return $indexer;
+    }
+
+    private function getAllDocumentsForFuzzyKeyword($words, $noLimit)
+    {
+        $binding_params = implode(',', array_fill(0, count($words), '?'));
+        $query = "SELECT * FROM doclist WHERE term_id in ($binding_params) ORDER BY hit_count DESC LIMIT {$this->maxDocs}";
+        if ($noLimit) {
+            $query = "SELECT * FROM doclist WHERE term_id in ($binding_params) ORDER BY hit_count DESC";
+        }
+        $stmtDoc = $this->index->prepare($query);
+
+        $ids = null;
+        foreach ($words as $word) {
+            $ids[] = $word['id'];
+        }
+        $stmtDoc->execute($ids);
+        return new Collection($stmtDoc->fetchAll(PDO::FETCH_ASSOC));
+    }
+
+    private function getAllDocumentsForStrictKeyword($word, $noLimit)
+    {
+        $query = "SELECT * FROM doclist WHERE term_id = :id ORDER BY hit_count DESC LIMIT {$this->maxDocs}";
+        if ($noLimit) {
+            $query = "SELECT * FROM doclist WHERE term_id = :id ORDER BY hit_count DESC";
+        }
+        $stmtDoc = $this->index->prepare($query);
+
+        $stmtDoc->bindValue(':id', $word[0]['id']);
+        $stmtDoc->execute();
+        return new Collection($stmtDoc->fetchAll(PDO::FETCH_ASSOC));
     }
 }


### PR DESCRIPTION
Don't search only for the first word if fuzziness is enabled. Main method refactored into two private methods.