### PR TITLE
Implementation of other Stemmer

### DIFF
--- a/src/TNTSearch.php
+++ b/src/TNTSearch.php
@@ -306,15 +306,19 @@ class TNTSearch
         return $docs->fetch(PDO::FETCH_ASSOC)['value'];
     }
 
-    public function setStemmer()
+    public function setStemmer($stemmer = null)
     {
-        $query = "SELECT * FROM info WHERE key = 'stemmer'";
-        $docs  = $this->index->query($query);
-        if ($language = $docs->fetch(PDO::FETCH_ASSOC)['value']) {
-            $class         = 'TeamTNT\\TNTSearch\\Stemmer\\' . ucfirst(strtolower($language)) . 'Stemmer';
-            $this->stemmer = new $class;
-        } else {
-            $this->stemmer = new PorterStemmer;
+        if(is_null($stemmer)) {
+            $query = "SELECT * FROM info WHERE key = 'stemmer'";
+            $docs = $this->index->query($query);
+            if ($language = $docs->fetch(PDO::FETCH_ASSOC)['value']) {
+                $class = 'TeamTNT\\TNTSearch\\Stemmer\\' . ucfirst(strtolower($language)) . 'Stemmer';
+                $this->stemmer = new $class;
+            } else {
+                $this->stemmer = new PorterStemmer;
+            }
+        }else{
+            $this->stemmer = $stemmer;
         }
     }
 


### PR DESCRIPTION
I would like to have a way to use another stemmer class like the one:
https://github.com/wamania/php-stemmer

It's possible?

From what I saw is fixed in the code the use of Stemmers:
`$class = 'TeamTNT\TNTSearch\Stemmer\' . ucfirst(strtolower($language)) . 'Stemmer';`

ps:sorry about my English

Thank you