### PR TITLE
execution_time key properly named for convenient usage

### DIFF
--- a/src/TNTSearch.php
+++ b/src/TNTSearch.php
@@ -124,7 +124,7 @@ class TNTSearch
         return [
             'ids'            => array_keys($docs->toArray()),
             'hits'           => $totalHits,
-            'execution time' => round($stopTimer - $startTimer, 7) * 1000 ." ms"
+            'execution_time' => round($stopTimer - $startTimer, 7) * 1000 ." ms"
         ];
     }
 
@@ -215,7 +215,7 @@ class TNTSearch
         return [
             'ids'            => $docs->toArray(),
             'hits'           => $docs->count(),
-            'execution time' => round($stopTimer - $startTimer, 7) * 1000 ." ms"
+            'execution_time' => round($stopTimer - $startTimer, 7) * 1000 ." ms"
         ];
     }
 


### PR DESCRIPTION
The earlier array key was "execution time" with space between which is not recommended.