### PR TITLE
execution_time key properly named for convenient usage

### DIFF
--- a/src/TNTGeoSearch.php
+++ b/src/TNTGeoSearch.php
@@ -23,7 +23,7 @@ class TNTGeoSearch extends TNTSearch
             'ids'            => $res->pluck('doc_id'),
             'distances'      => $res->pluck('distance'),
             'hits'           => $res->count(),
-            'execution time' => round($stopTimer - $startTimer, 7) * 1000 ." ms"
+            'execution_time' => round($stopTimer - $startTimer, 7) * 1000 ." ms"
         ];
     }
 


### PR DESCRIPTION
The earlier array key was "execution time" with space between which is not recommended.