### PR TITLE
method will not cut string correctly with russian language

### DIFF
--- a/src/Indexer/TNTIndexer.php
+++ b/src/Indexer/TNTIndexer.php
@@ -531,6 +531,8 @@ class TNTIndexer
         $t        = "__".$keyword."__";
         $trigrams = "";
         for ($i = 0; $i < strlen($t) - 2; $i++) {
+            mb_internal_encoding("UTF-8");
+            $trigrams .= mb_substr($t, $i, 3)." ";
             $trigrams .= substr($t, $i, 3)." ";
         }
 


### PR DESCRIPTION
Function substr() will not cut string correctly with russian language.