### PR TITLE
Case insensitive stemming.

### DIFF
--- a/src/Stemmer/PorterStemmer.php
+++ b/src/Stemmer/PorterStemmer.php
@@ -43,6 +43,8 @@ class PorterStemmer implements Stemmer
      */
     public static function stem($word)
     {
+        $word = mb_strtolower($word);
+
         if (strlen($word) <= 2) {
             return $word;
         }

--- a/tests/stemmer/PorterStemmerTest.php
+++ b/tests/stemmer/PorterStemmerTest.php
@@ -9,6 +9,7 @@ class PorterStemmerTestTest extends PHPUnit_Framework_TestCase
     {
         $stemmer = new PorterStemmer;
         $this->assertEquals("test", $stemmer->stem("testing"));
+        $this->assertEquals("test", $stemmer->stem("Testing"));
         $this->assertEquals("sourc", $stemmer->stem("source"));
         $this->assertEquals("code", $stemmer->stem("code"));
         $this->assertEquals("is", $stemmer->stem("is"));


### PR DESCRIPTION
After looking the example page, I noticed the search has problems with uppercase letters. See the example in the tests. 

These changes makes Porter behave like the other stemmers: lowercase the word in the first step.