### PR TITLE
Reset index statements after error was catched

### DIFF
--- a/src/Indexer/TNTIndexer.php
+++ b/src/Indexer/TNTIndexer.php
@@ -481,6 +481,11 @@ class TNTIndexer
                 } else {
                     echo "Error while saving wordlist: ".$e->getMessage()."\n";
                 }
+
+                // Statements must be refreshed, because in this state they have error attached to them.
+                $this->statementsPrepared = false;
+                $this->prepareStatementsForIndex();
+
             }
         }
         return $terms;


### PR DESCRIPTION
This PR fixes PHP 7.2 sqlite3 bug then `SQLSTATE[HY000]: General error: 21 bad parameter or other API misuse` error message is shown.

SQL Statements must be refreshed/reset after error was handled.

This also fixes: 
https://github.com/teamtnt/laravel-scout-tntsearch-driver/issues/129
https://github.com/teamtnt/laravel-scout-tntsearch-driver/issues/127