### PR TITLE
New feature: It's possible to add attributes to the highlighter tag.

### DIFF
--- a/src/Support/Highlighter.php
+++ b/src/Support/Highlighter.php
@@ -35,7 +35,7 @@ class Highlighter
             }
         }
 
-        $highlight = '<' . $tag . $tagAttributes .'>\1</' . $tag . '>';
+        $highlight = '<' . $tag . trim($tagAttributes) .'>\1</' . $tag . '>';
         $needle    = preg_split('/\PL+/u', $needle, -1, PREG_SPLIT_NO_EMPTY);
 
         // Select pattern to use

--- a/src/Support/Highlighter.php
+++ b/src/Support/Highlighter.php
@@ -9,6 +9,11 @@ class Highlighter
         'wholeWord'     => true,
         'caseSensitive' => false,
         'stripLinks'    => false,
+        'tagOptions' => [
+            // 'class' => 'search-term',             // Example
+            // 'title' => 'You searched for this.',  // Example
+            // 'data-toggle' => 'tooltip',           // Example
+        ]
     ];
 
 	/**
@@ -23,7 +28,14 @@ class Highlighter
     {
         $this->options = array_merge($this->options, $options);
 
-        $highlight = '<' . $tag . '>\1</' . $tag . '>';
+        $tagAttributes = ' ';
+        if (count($this->options['tagOptions'])) {
+            foreach ($this->options['tagOptions'] as $attr => $value) {
+                $tagAttributes .= $attr . '="' . $value . '" ';
+            }
+        }
+
+        $highlight = '<' . $tag . $tagAttributes .'>\1</' . $tag . '>';
         $needle    = preg_split('/\PL+/u', $needle, -1, PREG_SPLIT_NO_EMPTY);
 
         // Select pattern to use


### PR DESCRIPTION
This branch allows you to specify attributes to be added to the tag used to highlight search terms. So besides the tag to be used (`<em>` by default) you can specify attributes like` class="term"`, `title="You searched for this."` or `style="color: red;"` all in array format, where the key is the attribute name and the value is the attribute value.