### PR TITLE
Disable output on createIndex

### DIFF
--- a/src/TNTSearch.php
+++ b/src/TNTSearch.php
@@ -60,13 +60,15 @@ class TNTSearch
 
     /**
      * @param string $indexName
+     * @param boolean $disableOutput
      *
      * @return TNTIndexer
      */
-    public function createIndex($indexName)
+    public function createIndex($indexName, $disableOutput = false)
     {
         $indexer = new TNTIndexer;
         $indexer->loadConfig($this->config);
+        $indexer->disableOutput = $disableOutput;
 
         if ($this->dbh) {
             $indexer->setDatabaseHandle($this->dbh);


### PR DESCRIPTION
I followed your tutorial here http://tnt.studio/blog/did-you-mean-functionality-with-laravel-scout where you explain how to create trigrams.
If the function `createIndex` is called there is no way to disable the ouput of the `TNTINdexer`.
This is suboptimal if you have an api whereof you can create posts or sth. else and run the trigram generator directly after the creation process.

With this little it's possible to control this behavior.