### PR TITLE
Don't create connector if connection already exists

### DIFF
--- a/src/Indexer/TNTIndexer.php
+++ b/src/Indexer/TNTIndexer.php
@@ -206,8 +206,8 @@ class TNTIndexer
 
         $this->index->exec("CREATE INDEX IF NOT EXISTS 'main'.'term_id_index' ON doclist ('term_id' COLLATE BINARY);");
 
-        $connector = $this->createConnector($this->config);
         if (!$this->dbh) {
+            $connector = $this->createConnector($this->config);
             $this->dbh = $connector->connect($this->config);
         }
         return $this;


### PR DESCRIPTION
Hi,

I am using TNTSearch Driver for Laravel Scout with a custom Laravel database driver. TNTSearchScoutServiceProvider calls TNTSearch::setDatabaseHandle() and passes my custom PDO driver but TNTIndexer still tries to create a connector (which it would never use) and fails with an unsupported driver exception.

Thank you for your consideration.