### PR TITLE
feature: TNTIndexer 'extension' option as array or callable

### DIFF
--- a/src/Indexer/TNTIndexer.php
+++ b/src/Indexer/TNTIndexer.php
@@ -315,7 +315,16 @@ class TNTIndexer
 
         foreach ($objects as $name => $object) {
             $name = str_replace($path.'/', '', $name);
-            if (stringEndsWith($name, $this->config['extension']) && !in_array($name, $exclude)) {
+
+            if (is_callable($this->config['extension'])) {
+                $includeFile = $this->config['extension']($object);
+            } elseif (is_array($this->config['extension'])) {
+                $includeFile = in_array($object->getExtension(), $this->config['extension']);
+            } else {
+                $includeFile = stringEndsWith($name, $this->config['extension']);
+            }
+
+            if ($includeFile && !in_array($name, $exclude)) {
                 $counter++;
                 $file = [
                     'id'      => $counter,


### PR DESCRIPTION
This extends the `TNTIndexer` 'extension' option so that it can be a callable that returns a Boolean value or an array of extensions, or a string as before. This allows for indexing of several different file types at once.

For example, to index .html and .json files, either of these approaches could be taken:
```
$config = [
    ...
    "extension" => array('html','json'),
    ...
];
$tnt->loadConfig($config);
```
OR
```
$config = [
    ...
    "extension" => function($object) {
    	return in_array($object->getExtension(), array('json', 'html'));
    },
   ...
];
$tnt->loadConfig($config);
```

The callable approach allows for very flexible filtering, excluding specific subdirs or files that match the extension but should be excluded when matching a given RegEx for example.

In order to handle file contents by file type, this can be done in the read() method of a custom `FileReader`, for example by switching through `$fileinfo->getExtension()` or similiar and returning differently parsed content:
```
<?php
namespace Connum\TNTSearch\FileReaders;

use SplFileInfo;

class MyDynamicFileReader implements \TeamTNT\TNTSearch\FileReaders\FileReaderInterface
{
    public $fileMapCallback = null;
    public $fileFilterCallback = null;

    public function read(SplFileInfo $fileinfo)
    {
    	$content = file_get_contents($fileinfo);
    	$returnValue = '';

    	switch ($fileinfo->getExtension()) {
    		case 'html':
                        // this is an example using Html2Text to return the HTML markup as plaintext:
		    	$html = new \voku\Html2Text\Html2Text($content, array(
		    		'do_links' => 'none'
		    	));
		    	$returnValue = $html->getText();
    			break;
    		case 'json':
		    	// prepare JSON data for indexing, e.g.:
		    	$content = json_decode($content);
                        $returnValue = $content->headline . "\n" . $content->text . "\n" . implode(' ', $content->tags);
    			break;
    		default:
    			return '';
    	}

        return $returnValue;
    }
}
```