### PR TITLE
Code quality improvement + configurable stemmer

### DIFF
--- a/src/Support/Collection.php
+++ b/src/Support/Collection.php
@@ -8,7 +8,6 @@ use IteratorAggregate;
 
 class Collection implements Countable, IteratorAggregate
 {
-
     protected $items = [];
 
     public function __construct($items = [])
@@ -124,6 +123,26 @@ class Collection implements Countable, IteratorAggregate
     public function count()
     {
         return count($this->items);
+    }
+
+    /**
+     * @param int $offset
+     * @param int $length
+     *
+     * @return static
+     */
+    public function slice($offset, $length = null)
+    {
+        return new static(array_slice($this->items, $offset, $length, true));
+    }
+
+    /**
+     * @param int $limit
+     * @return static
+     */
+    public function take($limit)
+    {
+        return $this->slice(0, abs($limit));
     }
 
     /**

--- a/src/TNTSearch.php
+++ b/src/TNTSearch.php
@@ -116,10 +116,10 @@ class TNTSearch
         foreach ($keywords as $index => $term) {
             $isLastKeyword = ($keywords->count() - 1) == $index;
             $df            = $this->totalMatchingDocuments($term, $isLastKeyword);
+            $idf           = log($count / $df);
             foreach ($this->getAllDocumentsForKeyword($term, false, $isLastKeyword) as $document) {
                 $docID = $document['doc_id'];
                 $tf    = $document['hit_count'];
-                $idf   = log($count / $df);
                 $num   = ($tfWeight + 1) * $tf;
                 $denom = $tfWeight
                      * ((1 - $dlWeight) + $dlWeight)

--- a/src/TNTSearch.php
+++ b/src/TNTSearch.php
@@ -379,7 +379,7 @@ class TNTSearch
         if ($stemmer) {
             $this->stemmer = new $stemmer;
         } else {
-            $this->stemmer = new PorterStemmer;
+            $this->stemmer = isset($this->config['stemmer']) ? new $this->config['stemmer'] : new PorterStemmer;
         }
     }
 

--- a/src/TNTSearch.php
+++ b/src/TNTSearch.php
@@ -134,17 +134,10 @@ class TNTSearch
 
         $docs = new Collection($docScores);
 
-        $counter   = 0;
         $totalHits = $docs->count();
         $docs      = $docs->map(function ($doc, $key) {
             return $key;
-        })->filter(function ($item) use (&$counter, $numOfResults) {
-            $counter++;
-            if ($counter <= $numOfResults) {
-                return true;
-            }
-            return false; // ?
-        });
+        })->take($numOfResults);
         $stopTimer = microtime(true);
 
         if ($this->isFileSystemIndex()) {
@@ -233,14 +226,7 @@ class TNTSearch
             $docs = new Collection;
         }
 
-        $counter = 0;
-        $docs    = $docs->filter(function ($item) use (&$counter, $numOfResults) {
-            $counter++;
-            if ($counter <= $numOfResults) {
-                return $item;
-            }
-            return false; // ?
-        });
+        $docs = $docs->take($numOfResults);
 
         $stopTimer = microtime(true);
 

--- a/src/TNTSearch.php
+++ b/src/TNTSearch.php
@@ -116,7 +116,7 @@ class TNTSearch
         foreach ($keywords as $index => $term) {
             $isLastKeyword = ($keywords->count() - 1) == $index;
             $df            = $this->totalMatchingDocuments($term, $isLastKeyword);
-            $idf           = log($count / $df);
+            $idf           = log($count / max(1, $df));
             foreach ($this->getAllDocumentsForKeyword($term, false, $isLastKeyword) as $document) {
                 $docID = $document['doc_id'];
                 $tf    = $document['hit_count'];

--- a/tests/TNTSearchTest.php
+++ b/tests/TNTSearchTest.php
@@ -13,7 +13,8 @@ class TNTSearchTest extends PHPUnit_Framework_TestCase
         'host'     => 'localhost',
         'username' => 'testUser',
         'password' => 'testPass',
-        'storage'  => __DIR__.'/_files/'
+        'storage'  => __DIR__.'/_files/',
+        'stemmer'  => \TeamTNT\TNTSearch\Stemmer\PorterStemmer::class,
     ];
 
     public function testLoadConfig()
@@ -26,6 +27,7 @@ class TNTSearchTest extends PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('username', $tnt->config);
         $this->assertArrayHasKey('password', $tnt->config);
         $this->assertArrayHasKey('storage', $tnt->config);
+        $this->assertArrayHasKey('stemmer', $tnt->config);
     }
 
     public function testCreateIndex()
@@ -306,11 +308,36 @@ class TNTSearchTest extends PHPUnit_Framework_TestCase
         $tnt->selectIndex('IndexThatDoesNotExist');
     }
 
+    public function testStemmerIsSetOnNewIndexesBasedOnConfig()
+    {
+        $config = $this->config;
+        $config['stemmer'] = \TeamTNT\TNTSearch\Stemmer\GermanStemmer::class;
+
+        $tnt = new TNTSearch();
+        $tnt->loadConfig($config);
+        $tnt->createIndex($this->indexName);
+        $tnt->selectIndex($this->indexName);
+
+        $this->assertInstanceOf(\TeamTNT\TNTSearch\Stemmer\GermanStemmer::class, $tnt->getStemmer());
+    }
+
+    public function testDefaultStemmerIsSetOnNewIndexesIfNoneConfigured()
+    {
+        $config = $this->config;
+        unset($config['stemmer']);
+
+        $tnt = new TNTSearch();
+        $tnt->loadConfig($config);
+        $tnt->createIndex($this->indexName);
+        $tnt->selectIndex($this->indexName);
+
+        $this->assertInstanceOf(\TeamTNT\TNTSearch\Stemmer\PorterStemmer::class, $tnt->getStemmer());
+    }
+
     public function tearDown()
     {
         if (file_exists(__DIR__."/".$this->indexName)) {
             unlink(__DIR__."/".$this->indexName);
         }
-
     }
 }


### PR DESCRIPTION
This PR allows to configure the stemmer by setting a stemmer class in the `$config`. It also adds two new collection methods to clean up the `TNTSearch` code slightly.

Not sure if this has been attempted before, but I figured it would make sense to have a configurable stemmer if there are several to choose from. Or is there another way to configure the stemmer?