### PR TITLE
PR: reverts position of if condition made with older commit

### DIFF
--- a/src/TNTSearch.php
+++ b/src/TNTSearch.php
@@ -308,10 +308,6 @@ class TNTSearch
      */
     public function getWordlistByKeyword($keyword, $isLastWord = false)
     {
-        if ($this->fuzziness) {
-            return $this->fuzzySearch($keyword);
-        }
-
         $searchWordlist = "SELECT * FROM wordlist WHERE term like :keyword LIMIT 1";
         $stmtWord       = $this->index->prepare($searchWordlist);
 
@@ -325,6 +321,9 @@ class TNTSearch
         $stmtWord->execute();
         $res = $stmtWord->fetchAll(PDO::FETCH_ASSOC);
 
+        if ($this->fuzziness && !isset($res[0])) {
+            return $this->fuzzySearch($keyword);
+        }
         return $res;
     }
 


### PR DESCRIPTION
See https://github.com/teamtnt/tntsearch/issues/163 for further information for this fix.

If condition was moved in commit 40c4395cf04e089b6f2fd4dd98d4b1d09de1ce6b. But this causes a problem. Could be because function is called multiple times during one search.