### PR TITLE
Fix total hits in searchBoolean

### DIFF
--- a/src/TNTSearch.php
+++ b/src/TNTSearch.php
@@ -219,6 +219,7 @@ class TNTSearch
             $docs = new Collection;
         }
 
+        $totalHits = $docs->count();
         $docs = $docs->take($numOfResults);
 
         $stopTimer = microtime(true);
@@ -229,7 +230,7 @@ class TNTSearch
 
         return [
             'ids'            => $docs->toArray(),
-            'hits'           => $docs->count(),
+            'hits'           => $totalHits,
             'execution_time' => round($stopTimer - $startTimer, 7) * 1000 ." ms"
         ];
     }


### PR DESCRIPTION
Hits count returned in searchBoolean() is same as the number of results and not the total hits in the index for that phrase 