### PR TITLE
Check FileReader properties exist before accessing

### DIFF
--- a/src/Indexer/TNTIndexer.php
+++ b/src/Indexer/TNTIndexer.php
@@ -340,10 +340,12 @@ class TNTIndexer
                 ];
                 $fileCollection = new Collection($file);
 
-                if (is_callable($this->filereader->fileFilterCallback)) {
+                if (property_exists($this->filereader, 'fileFilterCallback')
+                    && is_callable($this->filereader->fileFilterCallback)) {
                     $fileCollection = $fileCollection->filter($this->filereader->fileFilterCallback);
                 }
-                if (is_callable($this->filereader->fileMapCallback)) {
+                if (property_exists($this->filereader, 'fileMapCallback')
+                    && is_callable($this->filereader->fileMapCallback)) {
                     $fileCollection = $fileCollection->map($this->filereader->fileMapCallback);
                 }
 


### PR DESCRIPTION
In pull request #151 a couple implicitly required properties were introduced to the `FileReaderInterface`: the `fileMapCallback` and `fileFilterCallback`.

For users creating their own implementation of the `FileReaderInterface`, if these properties don't exist a notice-level error is issued when `is_callable` is applied to them. In environments were all errors are upgraded to `ErrorException` this causes breakages.

Since PHP doesn't allow for properties to be defined by interfaces, I think the only way to handle this is to use `property_exists` before `is_callable`.

Here's a failing test case this PR addresses:

```php
<?php

include 'vendor/autoload.php';

use TeamTNT\TNTSearch\TNTSearch;
use TeamTNT\TNTSearch\FileReaders\FileReaderInterface;

error_reporting(-1);
set_error_handler(function ($level, $message, $file = '', $line = 0, $context = []) {
    throw new ErrorException($message, 0, $level, $file, $line);
});

class ExampleFileReader implements FileReaderInterface
{
    public function read(SplFileInfo $fileinfo)
    {
        return '';
    }
}

$search = new TNTSearch();
$search->loadConfig([
    'storage'   => '.',
    'driver'    => 'filesystem',
    'location'  => '.',
    'extension' => 'md',
]);
$indexer = $search->createIndex('example');
$indexer->setFileReader(new ExampleFileReader());
$indexer->run();
```

Let me know if tests are required and where I would put them. This is an awesome project, thanks for your time!