### PR TITLE
Add index for doc_id

### DIFF
--- a/src/Indexer/TNTIndexer.php
+++ b/src/Indexer/TNTIndexer.php
@@ -212,6 +212,7 @@ class TNTIndexer
         $this->index->exec("INSERT INTO info ( 'key', 'value') values ( 'total_documents', 0)");
 
         $this->index->exec("CREATE INDEX IF NOT EXISTS 'main'.'term_id_index' ON doclist ('term_id' COLLATE BINARY);");
+        $this->index->exec("CREATE INDEX IF NOT EXISTS 'main'.'doc_id_index' ON doclist ('doc_id');");
 
         if (!$this->dbh) {
             $connector = $this->createConnector($this->config);


### PR DESCRIPTION
While indexing my records through laravel scout commands I noticed, that the time it took to update records in the index changed linearly with the number of records that were already in the database, making indexing slower and slower. (Note: I am not using tntsearches indexing command, because I am also indexing relationships)

I tracked this down to the 2 queries on `doclist` in `TNTIndexer::delete` which took a while since they filtered for a column without an index on it. This leads the db to actually scan all records. Adding an index makes it more constant (-ish).

In theory, adding an index should impact insertion time a bit, but in my testing I found that this was offset by the time saved in the deletion queries very fast.

---

Here is the difference in indexing 20k records before and after adding the index:

Before:
![Screenshot_2020-04-03_12-04-04](https://user-images.githubusercontent.com/3374170/78350081-dfea9300-75a4-11ea-83a0-e89224aa3a02.png)

After:
![Screenshot_2020-04-03_12-04-17](https://user-images.githubusercontent.com/3374170/78350080-df51fc80-75a4-11ea-9dd2-d7f768bdb7c5.png)

As you can see, indexing now is not completely constant, but much better behaved that before.
 