### PR TITLE
Enhance boolean search expression.

### DIFF
--- a/src/Support/Expression.php
+++ b/src/Support/Expression.php
@@ -87,7 +87,7 @@ class Expression
     public function lex($string)
     {
         $bad  = [' or ', ' -', ' '];
-        $good = [ '|'  , '~', '&'];
+        $good = ['|', '~', '&'];
 
         $string = str_replace($bad, $good, $string);
         $string = mb_strtolower($string);

--- a/src/Support/Expression.php
+++ b/src/Support/Expression.php
@@ -86,8 +86,8 @@ class Expression
 
     public function lex($string)
     {
-        $bad  = [' or ', '-', ' ', '@', '.'];
-        $good = [ '|'  , '~', '&', '&', '&'];
+        $bad  = [' or ', ' -', ' '];
+        $good = [ '|'  , '~', '&'];
 
         $string = str_replace($bad, $good, $string);
         $string = mb_strtolower($string);

--- a/tests/support/ExpressionTest.php
+++ b/tests/support/ExpressionTest.php
@@ -15,7 +15,6 @@ class ExpressionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(['great', 'awsome', '|'], $exp->toPostfix("great or awsome"));
         $this->assertEquals(['great', 'awsome', '&'], $exp->toPostfix("great awsome"));
         $this->assertEquals(['email', 'test', '&', 'com', '&'], $exp->toPostfix("email test com"));
-        $this->assertEquals(['email', 'test', '&', 'com', '&'], $exp->toPostfix("email@test.com"));
         $this->assertEquals(['first', 'last', '&', 'something', 'else', '&', '|'], $exp->toPostfix("(first last) or (something else)"));
     }
 }


### PR DESCRIPTION
This patch changes two things:
1) When using custom Tokenizer, enables searching for UUIDs, product names and other items with dashes in their names by counting only space and dash character as an expression instead of just dash (see:
https://github.com/teamtnt/tntsearch/issues/161, https://github.com/teamtnt/tntsearch/issues/215, https://github.com/trilbymedia/grav-plugin-tntsearch/issues/92)
2) In some sense it partially reverts https://github.com/teamtnt/tntsearch/commit/33cc5244f02592e53ceffacf3c366e0b5111d7e8 as email address parts are broken into tokens in the default Tokenizer anyway.

P.S. Negative boolean search is still completely broken. It errors out on more than one negative expression ('searchstring -test -test2') and it returns incorrect results with one negative expression ('searchstring -test'). I will try to investigate this further.