### PR TITLE
Enhance default tokenizer.

### DIFF
--- a/src/Support/Tokenizer.php
+++ b/src/Support/Tokenizer.php
@@ -6,7 +6,7 @@ class Tokenizer implements TokenizerInterface
     public function tokenize($text, $stopwords = [])
     {
         $text  = mb_strtolower($text);
-        $split = preg_split("/[^\p{L}\p{N}]+/u", $text, -1, PREG_SPLIT_NO_EMPTY);
+        $split = preg_split("/[^\p{L}\p{N}\p{Pc}\p{Pd}@]+/u", $text, -1, PREG_SPLIT_NO_EMPTY);
         return array_diff($split, $stopwords);
     }
 }

--- a/tests/support/TokenizerTest.php
+++ b/tests/support/TokenizerTest.php
@@ -22,6 +22,7 @@ class TokenizerTest extends PHPUnit\Framework\TestCase
         $res  = $tokenizer->tokenize($text);
         $this->assertContains("test", $res);
         $this->assertContains("email", $res);
+        $this->assertContains("test@email", $res);
         $this->assertContains("contains", $res);
         $this->assertContains("123", $res);
 


### PR DESCRIPTION
I would like to propose improvements to the default TNTSearch Tokenizer. I've always felt that TNTSearch produces "unexpected" results from the user standpoint, especially when searching for more complex word forms in large text blocks. At first I thought improving ProductTokenizer by alternatively splitting by "/[\s,.:;"']/", but even this simple regex doesn't cover most common cases, hence my suggestion to enhance the default tokenizer.

This patch adds Unicode groups for dashes and connectors to the ignore list of split characters since they are mostly used inside words, not as word spliting characters. This enables searching for product models, SKU or UUID numbers, dates in their short form, function/constant names in programming manuals, etc.

While at it, also add @ character to the same list. Originally it belongs to Other punctuation Unicode group, but nowadays it is used more as a connector in email addresses or social network names than a separating character.

At least for me, this improves search results a lot.