### PR TITLE
Make highlighter use splitting pattern of the tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ class SomeTokenizer extends AbstractTokenizer implements TokenizerInterface
 }
 ```
 
-This pattern will split words using spaces, commas and periods.
+This tokenizer will split words using spaces, commas and periods.
 
 After you have the tokenizer ready, you should pass it to `TNTIndexer` via `setTokenizer` method.
 

--- a/README.md
+++ b/README.md
@@ -216,21 +216,25 @@ $index->delete(12);
 ```
 
 ## Custom Tokenizer
-First, create your own Tokenizer class that implements TokenizerInterface:
+First, create your own Tokenizer class. It should extend AbstractTokenizer class, define 
+word split $pattern value and must implement TokenizerInterface:
 
 ``` php
 
+use TeamTNT\TNTSearch\Support\AbstractTokenizer;
 use TeamTNT\TNTSearch\Support\TokenizerInterface;
 
-class SomeTokenizer implements TokenizerInterface {
+class SomeTokenizer extends AbstractTokenizer implements TokenizerInterface
+{
+    static protected $pattern = '/[\s,\.]+/';
 
     public function tokenize($text) {
-        return preg_split("/[^\p{L}\p{N}-]+/u", strtolower($text), -1, PREG_SPLIT_NO_EMPTY);
+        return preg_split($this->getPattern(), strtolower($text), -1, PREG_SPLIT_NO_EMPTY);
     }
 }
 ```
 
-The only difference here from the original is that the regex contains a dash `[^\p{L}\p{N}-]`
+This pattern will split words using spaces, commas and periods.
 
 After you have the tokenizer ready, you should pass it to `TNTIndexer` via `setTokenizer` method.
 
@@ -256,7 +260,7 @@ $tnt->loadConfig([
     'password'  => 'pass',
     'storage'   => '/var/www/tntsearch/examples/',
     'stemmer'   => \TeamTNT\TNTSearch\Stemmer\PorterStemmer::class//optional,
-    'tokenizer' => \TeamTNT\TNTSearch\Support\ProductTokenizer::class
+    'tokenizer' => \TeamTNT\TNTSearch\Support\SomeTokenizer::class
 ]);
 
 $indexer = $tnt->createIndex('name.index');

--- a/src/Support/AbstractTokenizer.php
+++ b/src/Support/AbstractTokenizer.php
@@ -1,0 +1,16 @@
+<?php
+namespace TeamTNT\TNTSearch\Support;
+
+abstract class AbstractTokenizer
+{
+    static protected $pattern = '';
+
+    public function getPattern()
+    {
+        if (empty(static::$pattern)) {
+            throw new \LogicException("Tokenizer must define split \$pattern value");
+        } else {
+            return static::$pattern;
+        }
+    }
+}

--- a/src/Support/Highlighter.php
+++ b/src/Support/Highlighter.php
@@ -16,6 +16,17 @@ class Highlighter
         ]
     ];
 
+    protected $tokenizer;
+
+    public function __construct(TokenizerInterface $tokenizer = null)
+    {
+        if (!empty($tokenizer)) {
+            $this->tokenizer = $tokenizer;
+        } else {
+            $this->tokenizer = new Tokenizer;
+        }
+    }
+
 	/**
 	 * @param        $text
 	 * @param        $needle
@@ -37,7 +48,7 @@ class Highlighter
         }
 
         $highlight = '<' . $tag . $tagAttributes .'>\1</' . $tag . '>';
-        $needle    = preg_split('/\PL+/u', $needle, -1, PREG_SPLIT_NO_EMPTY);
+        $needle    = preg_split($this->tokenizer->getPattern(), $needle, -1, PREG_SPLIT_NO_EMPTY);
 
         // Select pattern to use
         if ($this->options['simple']) {
@@ -165,7 +176,7 @@ class Highlighter
 	 */
     public function extractRelevant($words, $fulltext, $rellength = 300, $prevcount = 50, $indicator = '...')
     {
-        $words      = preg_split('/\PL+/u', $words, -1, PREG_SPLIT_NO_EMPTY);
+        $words      = preg_split($this->tokenizer->getPattern(), $words, -1, PREG_SPLIT_NO_EMPTY);
         $textlength = strlen($fulltext);
         if ($textlength <= $rellength) {
             return $fulltext;

--- a/src/Support/ProductTokenizer.php
+++ b/src/Support/ProductTokenizer.php
@@ -1,12 +1,14 @@
 <?php
 namespace TeamTNT\TNTSearch\Support;
 
-class ProductTokenizer implements TokenizerInterface
+class ProductTokenizer extends AbstractTokenizer implements TokenizerInterface
 {
+    static protected $pattern = '/[\s,]+/';
+
     public function tokenize($text, $stopwords = [])
     {
         $text  = mb_strtolower($text);
-        $split = preg_split("/[\s,]+/", $text, -1, PREG_SPLIT_NO_EMPTY);
+        $split = preg_split($this->getPattern(), $text, -1, PREG_SPLIT_NO_EMPTY);
         return array_diff($split, $stopwords);
     }
 }

--- a/src/Support/Tokenizer.php
+++ b/src/Support/Tokenizer.php
@@ -1,12 +1,14 @@
 <?php
 namespace TeamTNT\TNTSearch\Support;
 
-class Tokenizer implements TokenizerInterface
+class Tokenizer extends AbstractTokenizer implements TokenizerInterface
 {
+    static protected $pattern = '/[^\p{L}\p{N}\p{Pc}\p{Pd}@]+/u';
+
     public function tokenize($text, $stopwords = [])
     {
         $text  = mb_strtolower($text);
-        $split = preg_split("/[^\p{L}\p{N}\p{Pc}\p{Pd}@]+/u", $text, -1, PREG_SPLIT_NO_EMPTY);
+        $split = preg_split($this->getPattern(), $text, -1, PREG_SPLIT_NO_EMPTY);
         return array_diff($split, $stopwords);
     }
 }

--- a/src/Support/TokenizerInterface.php
+++ b/src/Support/TokenizerInterface.php
@@ -4,4 +4,6 @@ namespace TeamTNT\TNTSearch\Support;
 interface TokenizerInterface
 {
     public function tokenize($text, $stopwords);
+
+    public function getPattern();
 }

--- a/src/TNTSearch.php
+++ b/src/TNTSearch.php
@@ -436,13 +436,13 @@ class TNTSearch
      */
     public function highlight($text, $needle, $tag = 'em', $options = [])
     {
-        $hl = new Highlighter;
+        $hl = new Highlighter($this->tokenizer);
         return $hl->highlight($text, $needle, $tag, $options);
     }
 
     public function snippet($words, $fulltext, $rellength = 300, $prevcount = 50, $indicator = '...')
     {
-        $hl = new Highlighter;
+        $hl = new Highlighter($this->tokenizer);
         return $hl->extractRelevant($words, $fulltext, $rellength, $prevcount, $indicator);
     }
 

--- a/tests/indexer/TNTIndexerTest.php
+++ b/tests/indexer/TNTIndexerTest.php
@@ -181,7 +181,7 @@ class TNTIndexerTest extends PHPUnit\Framework\TestCase
 
 class SomeTokenizer extends AbstractTokenizer implements TokenizerInterface
 {
-    static protected $pattern = '/[\s,\.]+/'
+    static protected $pattern = '/[\s,\.]+/';
 
     public function tokenize($text, $stopwords = [])
     {

--- a/tests/indexer/TNTIndexerTest.php
+++ b/tests/indexer/TNTIndexerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use TeamTNT\TNTSearch\Indexer\TNTIndexer;
+use TeamTNT\TNTSearch\Support\AbstractTokenizer;
 use TeamTNT\TNTSearch\Support\TokenizerInterface;
 use TeamTNT\TNTSearch\TNTSearch;
 
@@ -178,11 +179,12 @@ class TNTIndexerTest extends PHPUnit\Framework\TestCase
     }
 }
 
-class SomeTokenizer implements TokenizerInterface
+class SomeTokenizer extends AbstractTokenizer implements TokenizerInterface
 {
+    static protected $pattern = '/[\s,\.]+/'
 
     public function tokenize($text, $stopwords = [])
     {
-        return preg_split("/[^\p{L}\p{N}-]+/u", mb_strtolower($text), -1, PREG_SPLIT_NO_EMPTY);
+        return preg_split($this->getPattern(), mb_strtolower($text), -1, PREG_SPLIT_NO_EMPTY);
     }
 }


### PR DESCRIPTION
This change makes highlighter word splitting pattern inline with what is used in the loaded tokenizer.

In order to take advantage of this tokenizers now should extend AbstractTokenizer class and define splitting pattern value in $pattern static protected variable.

I was not sure if this is the best way to do this, but I've tried to keep backward compatibility with possible custom tokenizers as much as possible. Most difficult question was if it is OK to modify TokenizerInterface by making getPattern() required. If we don't add it, the code which relies on custom tokenizers and uses Highlight class directly will fail with unknown method error. If we add it, at least Exception is thrown that tokenizer implementation needs to be adjusted according to interface specification.

Comments are welcome!