### PR TITLE
Make PHPUnit happier

### DIFF
--- a/src/Support/ProductTokenizer.php
+++ b/src/Support/ProductTokenizer.php
@@ -3,7 +3,7 @@ namespace TeamTNT\TNTSearch\Support;
 
 class ProductTokenizer extends AbstractTokenizer implements TokenizerInterface
 {
-    static protected $pattern = '/[\s,]+/';
+    static protected $pattern = '/[\s,\.]+/';
 
     public function tokenize($text, $stopwords = [])
     {

--- a/tests/stemmer/GermanStemmerTest.php
+++ b/tests/stemmer/GermanStemmerTest.php
@@ -2,7 +2,7 @@
 
 use TeamTNT\TNTSearch\Stemmer\GermanStemmer;
 
-class GermanStemmerTestTest extends PHPUnit\Framework\TestCase
+class GermanStemmerTest extends PHPUnit\Framework\TestCase
 {
 
     public function testStem()

--- a/tests/stemmer/PorterStemmerTest.php
+++ b/tests/stemmer/PorterStemmerTest.php
@@ -2,7 +2,7 @@
 
 use TeamTNT\TNTSearch\Stemmer\PorterStemmer;
 
-class PorterStemmerTestTest extends PHPUnit\Framework\TestCase
+class PorterStemmerTest extends PHPUnit\Framework\TestCase
 {
 
     public function testStem()

--- a/tests/stemmer/PortugueseStemmerTest.php
+++ b/tests/stemmer/PortugueseStemmerTest.php
@@ -2,7 +2,7 @@
 
 use TeamTNT\TNTSearch\Stemmer\PortugueseStemmer;
 
-class PortugueseStemmerTestTest extends PHPUnit\Framework\TestCase
+class PortugueseStemmerTest extends PHPUnit\Framework\TestCase
 {
 
     public function testStem()


### PR DESCRIPTION
Final patch this week - fixes deprecated warnings and adds period to the ProductTokenizer to pass the tests.

The only failing test now is TNTSearchTest::testSearchBoolean. Boolean search is completely broken probably because of this change https://github.com/teamtnt/tntsearch/commit/f2df690474e66af8b46a56723e07e9a4b2c4b6a9  I will try to investigate it next week.