### PR TITLE
Flag to return all FuzzySearch results on exact match

### DIFF
--- a/src/TNTSearch.php
+++ b/src/TNTSearch.php
@@ -301,7 +301,7 @@ class TNTSearch
      *
      * @return array
      */
-    public function getWordlistByKeyword($keyword, $isLastWord = false, $noLimit=false)
+    public function getWordlistByKeyword($keyword, $isLastWord = false, $noLimit = false)
     {
         $searchWordlist = "SELECT * FROM wordlist WHERE term like :keyword LIMIT 1";
         $stmtWord       = $this->index->prepare($searchWordlist);

--- a/tests/TNTSearchTest.php
+++ b/tests/TNTSearchTest.php
@@ -297,6 +297,29 @@ class TNTSearchTest extends PHPUnit\Framework\TestCase
         $this->assertContains(15, $res['ids']);
     }
 
+    public function testFuzzySearchOnExactMatchWithNoLimit()
+    {
+        $tnt = new TNTSearch();
+        $tnt->loadConfig($this->config);
+        $indexer                = $tnt->createIndex($this->indexName);
+        $indexer->disableOutput = true;
+        $indexer->query('SELECT id, title, article FROM articles;');
+        $indexer->run();
+
+        $tnt->selectIndex($this->indexName);
+        $index = $tnt->getIndex();
+
+        $index->insert(['id' => '14', 'title' => '199x', 'article' => 'Nineties with the x...']);
+        $index->insert(['id' => '15', 'title' => '199y', 'article' => 'Nineties with the y...']);
+        $tnt->fuzziness = true;
+        $res            = $tnt->search('199x');
+        $this->assertEquals([14], $res['ids']);
+
+        $tnt->fuzzy_no_limit    = true;
+        $res                    = $tnt->search('199x');
+        $this->assertEquals([14,15], $res['ids']);
+    }
+
     public function testIndexDoesNotExistException()
     {
         $this->expectException(IndexNotFoundException::class);


### PR DESCRIPTION
Currently, if FuzzySearch is enabled and the search term is an exact match it will only return the exact match and not attempt to do a fuzzy search. This change simply adds a flag that gives the developers the choice to return multiple results even on a direct match by running the fuzzySearch (if fuzziness is enabled).

This seems to have been attempted in a previous [issue](https://github.com/teamtnt/laravel-scout-tntsearch-driver/issues/172) but was subsequently rolled back #168  as people had complained about a reduction in search quality #163  . From what I gather the reason for the poor performance was due to search always returning the fuzzy match results over the exact match as most would have expected. This pr aims to keeps all logic as is unless the flag is set, only then should we see the entire fuzzy results on an exact match.