### PR TITLE
Add PHP 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.2
   - 7.3
   - 7.4snapshot
+  - 8.0
 
 addons:
   code_climate:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "role": "Developer"
     }],
     "require": {
-        "php": "~7.1",
+        "php": "~7.1|^8",
         "ext-pdo_sqlite": "*",
         "ext-sqlite3": "*",
         "ext-mbstring": "*"


### PR DESCRIPTION
This PR attempts to add support for the recently-released PHP 8, so that e.g., it can be upgraded along with Laravel Scout.