### PR TITLE
Fix infinite loop in search expression

### DIFF
--- a/src/Support/Expression.php
+++ b/src/Support/Expression.php
@@ -18,7 +18,7 @@ class Expression
                 $postfix[] = $token;
             } else {
                 if ($token == ")") {
-                    while (($top = array_pop($stack)) != "(") {
+                    while (($top = array_pop($stack)) != "(" && !empty($top)) {
                         $postfix[] = $top;
                     }
 

--- a/tests/support/ExpressionTest.php
+++ b/tests/support/ExpressionTest.php
@@ -9,6 +9,7 @@ class ExpressionTest extends PHPUnit\Framework\TestCase
         $exp = new Expression;
         $this->assertEquals(['a', 'b', '&', 'c', '|'], $exp->toPostfix("a&b|c"));
         $this->assertEquals(['aw', 'bw', '&', 'cw', '|'], $exp->toPostfix("aw&bw|cw"));
+        $this->assertEquals(['aw', 'bw', '&', 'cw', '|'], $exp->toPostfix("aw&bw|cw)"));
         $this->assertEquals(['a', 'b', 'd', 'c', '&', '|', '&'], $exp->toPostfix("a&(b|d&c)"));
         $this->assertEquals(['a', 'b', '|'], $exp->toPostfix("a|b"));
         $this->assertEquals(['great', 'awsome', '|'], $exp->toPostfix("great|awsome"));
@@ -16,5 +17,7 @@ class ExpressionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(['great', 'awsome', '&'], $exp->toPostfix("great awsome"));
         $this->assertEquals(['email', 'test', '&', 'com', '&'], $exp->toPostfix("email test com"));
         $this->assertEquals(['first', 'last', '&', 'something', 'else', '&', '|'], $exp->toPostfix("(first last) or (something else)"));
+        $this->assertEquals(['first', 'last', '|', 'something', 'else', '|', '&'], $exp->toPostfix("(first or last)&(something or else)"));
+        $this->assertEquals(['first', 'last', '|', 'something', '&', 'else', '|'], $exp->toPostfix("(first or last)&something or else)"));
     }
 }


### PR DESCRIPTION
If search query didn't contain opening parentheses this while loop produced memory exhausted errors.

Not sure if this a right way to fix this, but if stack is empty or have reached the end array_pop should return null.

Also, add some tests to catch these cases.