### PR TITLE
Added `ReturnTypeWillChange` PHP 8.1 attribute.

### DIFF
--- a/src/Support/Collection.php
+++ b/src/Support/Collection.php
@@ -148,6 +148,7 @@ class Collection implements Countable, IteratorAggregate
     /**
      * @return ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->items);


### PR DESCRIPTION
Added `ReturnTypeWillChange` attribute so the deprecation notice in PHP 8.1 is not emitted:

```
Return type of TeamTNT\TNTSearch\Support\Collection::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```