### PR TITLE
:sparkles: Introducing ability to make docScores available outside of TNTSearch

### DIFF
--- a/src/TNTSearch.php
+++ b/src/TNTSearch.php
@@ -139,6 +139,7 @@ class TNTSearch
         return [
             'ids'            => array_keys($docs->toArray()),
             'hits'           => $totalHits,
+            'docScores'      => $docScores,
             'execution_time' => round($stopTimer - $startTimer, 7) * 1000 ." ms"
         ];
     }


### PR DESCRIPTION
# General
In order to make it possible to rank different laravel models by score, we'll need the docScores to make use in it in the laravel provider plugin (see pr: https://github.com/teamtnt/laravel-scout-tntsearch-driver/pull/344)

# Will also solve the follow issues
#55

# These changes also affect
https://github.com/teamtnt/laravel-scout-tntsearch-driver/pull/344
https://github.com/teamtnt/laravel-scout-tntsearch-driver/issues/222