### PR TITLE
Update SQLiteConnector to avoid depreciation on string with PHP 8.2

### DIFF
--- a/src/Connectors/SQLiteConnector.php
+++ b/src/Connectors/SQLiteConnector.php
@@ -32,7 +32,7 @@ class SQLiteConnector extends Connector implements ConnectorInterface
         // as the developer probably wants to know if the database exists and this
         // SQLite driver will not throw any exception if it does not by default.
         if ($path === false) {
-            throw new Exception("Database (${config['database']}) does not exist.");
+            throw new Exception("Database ({$config['database']}) does not exist.");
         }
 
         return $this->createConnection("sqlite:{$path}", $config, $options);


### PR DESCRIPTION
#281 Update SQLiteConnector to avoid depreciation : Using ${var} in strings is deprecated, use {$var} instead in PHP 8.2