### PR TITLE
#285 fixing Deprecated: Creation of dynamic property

### DIFF
--- a/src/Indexer/TNTIndexer.php
+++ b/src/Indexer/TNTIndexer.php
@@ -18,7 +18,7 @@ use TeamTNT\TNTSearch\Support\Collection;
 use TeamTNT\TNTSearch\Support\Tokenizer;
 use TeamTNT\TNTSearch\Support\TokenizerInterface;
 
-class TNTIndexer
+class TNTIndexer  extends \stdClass
 {
     protected $index              = null;
     protected $dbh                = null;


### PR DESCRIPTION
One solution find to fix Deprecated: Creation of dynamic property, is to add an inheritance with \stdClass. There's  some others solution to fix this deprecation.