### PR TITLE
docs: fix fuzziness method example

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ $tnt = new TNTSearch;
 
 $tnt->loadConfig($config);
 $tnt->selectIndex("name.index");
-$tnt->fuzziness = true;
+$tnt->fuzziness(true);
 
 //when the fuzziness flag is set to true, the keyword juleit will return
 //documents that match the word juliet, the default Levenshtein distance is 2


### PR DESCRIPTION
I noticed an issue in the readme file where the example for fuzziness was incorrect. It incorrectly sets the "fuzziness" attribute, which doesn't exist. Instead, it should call the "fuzziness" method.

❌ `$tnt->fuzziness = true;`
✅ `$tnt->fuzziness(true);`

This pull request (PR) corrects the example by using the appropriate methods.