### PR TITLE
SqliteEngine can create index storage parent directory if needed

### DIFF
--- a/src/Engines/SqliteEngine.php
+++ b/src/Engines/SqliteEngine.php
@@ -58,6 +58,10 @@ class SqliteEngine implements EngineContract
 
         $this->flushIndex($indexName);
 
+        if(!file_exists($this->config['storage'])) {    // create the parent folder, if doesn't exist
+            mkdir($this->config['storage'], 0700, true);
+        }
+
         $this->index = new PDO('sqlite:' . $this->config['storage'] . $indexName);
         $this->index->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 


### PR DESCRIPTION
This avoids a fatal error on initial run, if using an unversioned storage area that is hard to set up initialised (but still allows for custom organisation of that storage area)