### PR TITLE
Avoid deprecated message for null string

### DIFF
--- a/src/Support/Tokenizer.php
+++ b/src/Support/Tokenizer.php
@@ -7,7 +7,7 @@ class Tokenizer extends AbstractTokenizer implements TokenizerInterface
 
     public function tokenize($text, $stopwords = [])
     {
-        $text  = mb_strtolower($text);
+        $text  = mb_strtolower($text ?? '');
         $split = preg_split($this->getPattern(), $text, -1, PREG_SPLIT_NO_EMPTY);
         return array_diff($split, $stopwords);
     }


### PR DESCRIPTION
PHP 8.1 gives this error if a null value makes its way to this method

mb_strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/app/vendor/teamtnt/tntsearch/src/Support/Tokenizer.php on line 10