### PR TITLE
[MySQL engine ] Add hit_count to doclist database index

### DIFF
--- a/src/Engines/MysqlEngine.php
+++ b/src/Engines/MysqlEngine.php
@@ -71,7 +71,7 @@ class MysqlEngine extends SqliteEngine
             ( 'tokenizer', 'TeamTNT\TNTSearch\Support\Tokenizer')"
         );
 
-        $this->index->exec("ALTER TABLE ".$this->indexName."_doclist ADD INDEX idx_term_id_hit_count (`term_id`, `hit_count`);");
+        $this->index->exec("ALTER TABLE ".$this->indexName."_doclist ADD INDEX idx_term_id_hit_count (`term_id`, `hit_count` DESC);");
         $this->index->exec("ALTER TABLE ".$this->indexName."_doclist ADD INDEX idx_doc_id (`doc_id`);");
 
         if (isset($this->config['stemmer'])) {

--- a/src/Engines/MysqlEngine.php
+++ b/src/Engines/MysqlEngine.php
@@ -71,7 +71,7 @@ class MysqlEngine extends SqliteEngine
             ( 'tokenizer', 'TeamTNT\TNTSearch\Support\Tokenizer')"
         );
 
-        $this->index->exec("ALTER TABLE ".$this->indexName."_doclist ADD INDEX idx_term_id (`term_id`);");
+        $this->index->exec("ALTER TABLE ".$this->indexName."_doclist ADD INDEX idx_term_id_hit_count (`term_id`, `hit_count`);");
         $this->index->exec("ALTER TABLE ".$this->indexName."_doclist ADD INDEX idx_doc_id (`doc_id`);");
 
         if (isset($this->config['stemmer'])) {


### PR DESCRIPTION
Currently there is this index:
https://github.com/teamtnt/tntsearch/blob/a763e66ca1bdebf1fab8f9ed10ec4bdbe2682bb0/src/Engines/MysqlEngine.php#L74

For retrieving all documents for a certain term the following query gets used:
https://github.com/teamtnt/tntsearch/blob/a763e66ca1bdebf1fab8f9ed10ec4bdbe2682bb0/src/Engines/MysqlEngine.php#L385

With the current index, this needs to sort the results with `filesort`:
<img width="1050" alt="Bildschirmfoto 2024-09-03 um 07 33 32" src="https://github.com/user-attachments/assets/1eaf416e-92c4-45d3-be3c-0ecc47f706f5">

When we also add `hit_count` to the index, the `filesort` is not necessary anymore but filtering and sorting gets fully covered by the index:
<img width="1083" alt="Bildschirmfoto 2024-09-03 um 07 36 50" src="https://github.com/user-attachments/assets/e85b927d-ab40-4146-bab8-eac7c95a8ea0">

This results in better performance.

There is no drawback for other queries which only filter by `term_id` as MySQL in this case can also use the index prefix (in this case only the column `term_id`).