### PR TITLE
Remove duplicate unique index for wordlist table

### DIFF
--- a/src/Engines/MysqlEngine.php
+++ b/src/Engines/MysqlEngine.php
@@ -30,7 +30,7 @@ class MysqlEngine extends SqliteEngine
         $this->index->exec(
             'CREATE TABLE IF NOT EXISTS '.$this->indexName.'_wordlist (
                     id INTEGER PRIMARY KEY AUTO_INCREMENT,
-                    term VARCHAR(255) UNIQUE,
+                    term VARCHAR(255),
                     num_hits INTEGER,
                     num_docs INTEGER)'
         );


### PR DESCRIPTION
The UNIQUE index for `wordlist.term` gets created in https://github.com/teamtnt/tntsearch/blob/069e63e377da578ddf8b9524dd97e463499150b3/src/Engines/MysqlEngine.php#L38

One of the 2 places can be removed.