### PR TITLE
[MySQL engine] Update for wordlist overwrote num_docs + num_hits instead of adding to previous value

### DIFF
--- a/src/Engines/MysqlEngine.php
+++ b/src/Engines/MysqlEngine.php
@@ -165,7 +165,7 @@ class MysqlEngine extends SqliteEngine
                 $insertRows[] = '('.$this->index->quote($key).', '.$this->index->quote($term['hits']).', '.$this->index->quote($term['docs']).')';
             }
 
-            $this->index->exec('INSERT INTO '.$this->indexName.'_wordlist (term, num_hits, num_docs) VALUES '.implode(',', $insertRows).' ON DUPLICATE KEY UPDATE num_docs=VALUES(num_docs), num_hits=VALUES(num_docs)');
+            $this->index->exec('INSERT INTO '.$this->indexName.'_wordlist (term, num_hits, num_docs) VALUES '.implode(',', $insertRows).' ON DUPLICATE KEY UPDATE num_docs=num_docs+VALUES(num_docs), num_hits=num_hits+VALUES(num_docs)');
 
             $termIds = $this->index->query('SELECT id, term FROM '.$this->indexName.'_wordlist WHERE term IN ('.implode(',', array_map([$this->index, 'quote'], array_keys($termChunk))).')');
             foreach ($termIds as $termId) {


### PR DESCRIPTION
Compare with Sqlite approach:
https://github.com/teamtnt/tntsearch/blob/069e63e377da578ddf8b9524dd97e463499150b3/src/Engines/SqliteEngine.php#L225

Currently `num_docs` and `num_hits` are overwritten with every update.