### PR TITLE
Remove sqlite PHP extension as it is only an optional dependency nowadays

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,6 @@
     }],
     "require": {
         "php": "~7.1|^8",
-        "ext-pdo_sqlite": "*",
-        "ext-sqlite3": "*",
         "ext-mbstring": "*",
         "predis/predis": "^2.2"
     },


### PR DESCRIPTION
After #316 brought support for MySQL, the `SQlite` PHP extension became optional.

Btw: When will there be a released tag / version based on current `master` branch`?