### PR TITLE
Explicitly declare parameter as nullable

### DIFF
--- a/src/Support/Collection.php
+++ b/src/Support/Collection.php
@@ -42,7 +42,7 @@ class Collection implements Countable, IteratorAggregate
      *
      * @return static
      */
-    public function filter(callable $callback = null)
+    public function filter(?callable $callback = null)
     {
         if ($callback) {
             $return = [];


### PR DESCRIPTION
PHP have deprecated the implicit nullable parameter for functions. 

The ?callable explicitly marks the $callback parameter as nullable. This change ensures compatibility with newer PHP versions while keeping the functionality the same.