### PR TITLE
Use properly prefixed 'doclist' table

### DIFF
--- a/src/Engines/MysqlEngine.php
+++ b/src/Engines/MysqlEngine.php
@@ -369,9 +369,9 @@ class MysqlEngine extends SqliteEngine
         if (!isset($word[0])) {
             return new Collection([]);
         }
-        $query = "SELECT * FROM ".$this->indexName."_doclist WHERE doc_id NOT IN (SELECT doc_id FROM doclist WHERE term_id = :id) GROUP BY doc_id ORDER BY hit_count DESC LIMIT {$this->maxDocs}";
+        $query = "SELECT * FROM ".$this->indexName."_doclist WHERE doc_id NOT IN (SELECT doc_id FROM ".$this->indexName."_doclist WHERE term_id = :id) GROUP BY doc_id ORDER BY hit_count DESC LIMIT {$this->maxDocs}";
         if ($noLimit) {
-            $query = 'SELECT * FROM '.$this->indexName.'_doclist WHERE doc_id NOT IN (SELECT doc_id FROM doclist WHERE term_id = :id) GROUP BY doc_id ORDER BY hit_count DESC';
+            $query = 'SELECT * FROM '.$this->indexName.'_doclist WHERE doc_id NOT IN (SELECT doc_id FROM '.$this->indexName.'_doclist WHERE term_id = :id) GROUP BY doc_id ORDER BY hit_count DESC';
         }
         $stmtDoc = $this->index->prepare($query);
 


### PR DESCRIPTION
This pull request relates to issue #327 

It solves an issue when using `searchBoolean()` with the `MysqlEngine` - previously the `doclist` table was not properly prefixed, resulting in an error:

```
 SQLSTATE[42S02]: Base table or view not found: 1146 Table 'db.doclist' doesn't exist
```