### PR TITLE
Add additional 'Processed x rows' after the loop, fixed #312

### DIFF
--- a/src/Engines/RedisEngine.php
+++ b/src/Engines/RedisEngine.php
@@ -114,6 +114,8 @@ class RedisEngine implements EngineInterface
             }
         }
 
+        $this->info("Processed {$counter} rows");
+
         $this->updateInfoTable('total_documents', $counter);
 
         $this->info("Total rows {$counter}");

--- a/src/Engines/RedisEngine.php
+++ b/src/Engines/RedisEngine.php
@@ -109,12 +109,14 @@ class RedisEngine implements EngineInterface
 
             $this->processDocument(new Collection($row));
 
-            if ($counter % $this->steps == 0) {
+            if ($counter % $this->steps === 0) {
                 $this->info("Processed {$counter} rows");
             }
         }
 
-        $this->info("Processed {$counter} rows");
+        if ($counter % $this->steps !== 0) {
+            $this->info("Processed {$counter} rows");
+        }
 
         $this->updateInfoTable('total_documents', $counter);
 

--- a/src/Engines/SqliteEngine.php
+++ b/src/Engines/SqliteEngine.php
@@ -172,7 +172,10 @@ class SqliteEngine implements EngineInterface
                 $this->info("Committed");
             }
         }
+
+        $this->info("Processed {$counter} rows");
         $this->index->commit();
+        $this->info("Committed");
 
         $this->updateInfoTable('total_documents', $counter);
 

--- a/src/Engines/SqliteEngine.php
+++ b/src/Engines/SqliteEngine.php
@@ -163,19 +163,25 @@ class SqliteEngine implements EngineInterface
 
             $this->processDocument(new Collection($row));
 
-            if ($counter % $this->steps == 0) {
+            if ($counter % $this->steps === 0) {
                 $this->info("Processed {$counter} rows");
             }
-            if ($counter % 10000 == 0) {
+
+            if ($counter % 10000 === 0) {
                 $this->index->commit();
                 $this->index->beginTransaction();
                 $this->info("Committed");
             }
         }
 
-        $this->info("Processed {$counter} rows");
-        $this->index->commit();
-        $this->info("Committed");
+        if ($counter % $this->steps !== 0) {
+            $this->info("Processed {$counter} rows");
+        }
+
+        if ($counter % 10000 !== 0) {
+            $this->index->commit();
+            $this->info("Committed");
+        }
 
         $this->updateInfoTable('total_documents', $counter);
 


### PR DESCRIPTION
Hello,

this is just a very small PR to add an additional `info` after the index loop to clear up that all given rows have been processed. See discussion in https://github.com/teamtnt/tntsearch/issues/312 