### PR TITLE
Fix 'MysqlEngine->selectIndex()' when index has not been set previously

### DIFF
--- a/src/Engines/MysqlEngine.php
+++ b/src/Engines/MysqlEngine.php
@@ -100,7 +100,7 @@ class MysqlEngine extends SqliteEngine
 
     public function selectIndex(string $indexName)
     {
-        if ($this->index === null || $this->indexName !== $indexName) {
+        if (!isset($this->index) || $this->indexName !== $indexName) {
             $this->setIndexName($indexName);
             $this->index = new PDO('mysql:dbname='.$this->config['database'].';host='.$this->config['host'], $this->config['username'], $this->config['password']);
             $this->index->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);


### PR DESCRIPTION
Hello,

while working on improved types (regarding PHP 7.4 & 8+) I overlooked this issue - we need to check if the variable is set rather than checking the content.

By checking the value the logic will evaluate and throw

```
Uncaught Error: Typed property TeamTNT\TNTSearch\Engines\SqliteEngine::$index must not be accessed before initialization in
```