### PR TITLE
Create 'mariadb' alias refs #349

### DIFF
--- a/src/Engines/EngineTrait.php
+++ b/src/Engines/EngineTrait.php
@@ -37,6 +37,7 @@ trait EngineTrait
 
         switch ($config['driver']) {
             case 'mysql':
+            case 'mariadb':
                 return new MySqlConnector;
             case 'pgsql':
                 return new PostgresConnector;


### PR DESCRIPTION
Hello,

here we create a `mariadb` driver alias which uses the `MySqlConnector` internally.

Best regards