### PR TITLE
Avoid deprecated message for null string

### DIFF
--- a/src/Tokenizer/EdgeNgramTokenizer.php
+++ b/src/Tokenizer/EdgeNgramTokenizer.php
@@ -7,7 +7,11 @@ class EdgeNgramTokenizer extends AbstractTokenizer implements TokenizerInterface
 
     public function tokenize($text, $stopwords = [])
     {
-        $text = mb_strtolower($text);
+        if (!is_scalar($text)) {
+            return [];
+        }
+
+        $text = mb_strtolower((string)$text);
 
         $ngrams = [];
         $splits = preg_split($this->getPattern(), $text, -1, PREG_SPLIT_NO_EMPTY);

--- a/src/Tokenizer/NGramTokenizer.php
+++ b/src/Tokenizer/NGramTokenizer.php
@@ -16,7 +16,11 @@ class NGramTokenizer extends AbstractTokenizer implements TokenizerInterface
 
     public function tokenize($text, $stopwords = [])
     {
-        $text = mb_strtolower($text);
+        if (!is_scalar($text)) {
+            return [];
+        }
+
+        $text = mb_strtolower((string)$text);
 
         $ngrams = [];
         $splits = preg_split($this->getPattern(), $text, -1, PREG_SPLIT_NO_EMPTY);

--- a/src/Tokenizer/ProductTokenizer.php
+++ b/src/Tokenizer/ProductTokenizer.php
@@ -7,7 +7,11 @@ class ProductTokenizer extends AbstractTokenizer implements TokenizerInterface
 
     public function tokenize($text, $stopwords = [])
     {
-        $text  = mb_strtolower($text);
+        if (!is_scalar($text)) {
+            return [];
+        }
+
+        $text  = mb_strtolower((string)$text);
         $split = preg_split($this->getPattern(), $text, -1, PREG_SPLIT_NO_EMPTY);
         return array_diff($split, $stopwords);
     }

--- a/src/Tokenizer/Tokenizer.php
+++ b/src/Tokenizer/Tokenizer.php
@@ -7,7 +7,11 @@ class Tokenizer extends AbstractTokenizer implements TokenizerInterface
 
     public function tokenize($text, $stopwords = [])
     {
-        $text  = mb_strtolower($text);
+        if (!is_scalar($text)) {
+            return [];
+        }
+
+        $text  = mb_strtolower((string)$text);
         $split = preg_split($this->getPattern(), $text, -1, PREG_SPLIT_NO_EMPTY);
         return array_diff($split, $stopwords);
     }

--- a/tests/tokenizer/TokenizerTest.php
+++ b/tests/tokenizer/TokenizerTest.php
@@ -39,4 +39,27 @@ class TokenizerTest extends TestCase
         $this->assertContains("čćž", $res);
         $this->assertContains("šđ", $res);
     }
+
+    public function testEmptyTokenizeResults()
+    {
+        $tokenizer = new Tokenizer;
+
+        // Empty string.
+        $this->assertEquals([], $tokenizer->tokenize(''));
+
+        // 'false' results in empty string.
+        $this->assertEquals([], $tokenizer->tokenize(false));
+
+        // 'null' results in empty string.
+        $this->assertEquals([], $tokenizer->tokenize(null));
+
+        // 'array' results in empty string.
+        $this->assertEquals([], $tokenizer->tokenize([]));
+
+         // 'object' results in empty string.
+        $this->assertEquals([], $tokenizer->tokenize(new \stdClass()));
+
+        // 'resource' results in empty string.
+        $this->assertEquals([], $tokenizer->tokenize(tmpfile()));
+    }
 }


### PR DESCRIPTION
Hello,

this pull-requests implements the change from #310 including some more situations.
I also added a unit test for "invalid" types, they should return empty tokenize results and not throw an error.

In the future the `tokenize` method should use a typed parameter and only be called, if a string was given.

Best regards
Leo